### PR TITLE
Integrate PM2 for deployment

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -18,12 +18,25 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.SSH_KEY }}
 
+      - name: Install PM2 globally using yarn
+        run: |
+          ssh -o StrictHostKeyChecking=no ${{ secrets.USERNAME }}@${{ secrets.HOST }} << EOF
+            if ! command -v pm2 &> /dev/null
+            then
+              yarn global add pm2
+            fi
+          EOF
+
       - name: Deploy
         run: |
           ssh -o StrictHostKeyChecking=no ${{ secrets.USERNAME }}@${{ secrets.HOST }} << EOF
             set -e
             cd ~/vanjacloud.remote
-            # Your deployment commands go here
             git fetch origin && git reset --hard origin/$(git branch --show-current) && git clean -fd
             /home/vanjacloud/.bun/bin/bun install
+            if pm2 list | grep -q vanjacloud; then
+              pm2 reload vanjacloud
+            else
+              pm2 start 'bun --hot run src/main.ts' --name vanjacloud
+            fi
           EOF


### PR DESCRIPTION
Related to #2

Updates the deployment process to utilize PM2 for running the application on the DigitalOcean droplet, ensuring both initial addition and updates are handled.

- **Installs PM2 globally** using yarn if it is not already installed, ensuring the deployment environment is prepared for PM2 management.
- **Checks if the application is already running** under PM2 and either starts it with `pm2 start 'bun --hot run src/main.ts' --name vanjacloud` or updates it using `pm2 reload vanjacloud`, facilitating seamless deployment and updates.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/vanjaoljaca/vanjacloud.remote/issues/2?shareId=419f83db-581a-401f-a979-44ce85fee115).