### PR TITLE
Add version endpoint and deployment verification

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -18,6 +18,12 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.SSH_KEY }}
 
+      - name: Update package.json version
+        run: |
+          git fetch --tags
+          VERSION=$(git rev-parse HEAD)
+          ssh -o StrictHostKeyChecking=no ${{ secrets.USERNAME }}@${{ secrets.HOST }} "echo '{\"version\": \"'$VERSION'\"}' > package.json"
+
       - name: Install PM2 globally using yarn
         run: |
           ssh -o StrictHostKeyChecking=no ${{ secrets.USERNAME }}@${{ secrets.HOST }} << EOF
@@ -40,3 +46,14 @@ jobs:
               pm2 start 'bun --hot run src/main.ts' --name vanjacloud
             fi
           EOF
+
+      - name: Verify deployment
+        run: |
+          VERSION=$(git rev-parse HEAD)
+          RESPONSE=$(curl -s http://remote.vanja.oljaca.me:3000/version)
+          if [ "$RESPONSE" != "$VERSION" ]; then
+            echo "Deployment verification failed. Expected version $VERSION, got $RESPONSE"
+            exit 1
+          else
+            echo "Deployment verified successfully."
+          fi

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import OpenAI from "openai";
 import moment from "moment";
 import Path from 'path'
 import vanjacloud, { Thought } from 'vanjacloud.shared.js';
+import { execSync } from 'child_process';
 
 const thoughtDb = new Thought.ThoughtDB(vanjacloud.Keys.notion, process.env.NOTION_THOUGHTDB!);
 
@@ -68,6 +69,10 @@ export default new Router({
     hostname: '0.0.0.0' // no idea why this is needed remotely to not use 127
 })
     .get('/', () => new Response('Hi'))
+    .get('/version', () => {
+        const version = execSync('git rev-parse HEAD').toString().trim();
+        return new Response(version);
+    })
     .post('/', () => new Response('Hi'))
     .post('/retrospective', async (req) => {
         const data = await req.json()


### PR DESCRIPTION
Related to #4

Adds a `/version` endpoint and automates version updates on deployment.

- **Endpoint Implementation**: Introduces a new route in `src/main.ts` for `/version` that dynamically fetches and returns the git commit ID as the version number. This ensures that the version number reflects the latest deployment.
- **Deployment Automation**: Updates `.github/workflows/deploy.yaml` to include steps for updating the `package.json` version field with the git commit ID before deployment and verifying the `/version` endpoint returns the updated version number post-deployment. This automation streamlines the deployment process and ensures the deployed version is correctly reflected.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/vanjaoljaca/vanjacloud.remote/issues/4?shareId=e8f6565c-3dde-4ed3-a4b3-f8f43733b653).