### PR TITLE
Fix PM2 deployment issue

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -24,12 +24,12 @@ jobs:
           VERSION=$(git rev-parse HEAD)
           ssh -o StrictHostKeyChecking=no ${{ secrets.USERNAME }}@${{ secrets.HOST }} "echo '{\"version\": \"'$VERSION'\"}' > package.json"
 
-      - name: Install PM2 globally using yarn
+      - name: Install PM2 globally using bun
         run: |
           ssh -o StrictHostKeyChecking=no ${{ secrets.USERNAME }}@${{ secrets.HOST }} << EOF
             if ! command -v pm2 &> /dev/null
             then
-              yarn global add pm2
+              bun add pm2 -g
             fi
           EOF
 
@@ -39,11 +39,11 @@ jobs:
             set -e
             cd ~/vanjacloud.remote
             git fetch origin && git reset --hard origin/$(git branch --show-current) && git clean -fd
-            /home/vanjacloud/.bun/bin/bun install
-            if pm2 list | grep -q vanjacloud; then
-              pm2 reload vanjacloud
+            ~/.bun/bin/bun install
+            if ~/.bun/bin/pm2 list | grep -q vanjacloud; then
+              ~/.bun/bin/pm2 reload vanjacloud
             else
-              pm2 start 'bun --hot run src/main.ts' --name vanjacloud
+              ~/.bun/bin/pm2 start 'bun --hot run src/main.ts' --name vanjacloud
             fi
           EOF
 


### PR DESCRIPTION
Related to #6

Updates the deployment process to use `bun` for installing and setting the path for `pm2`.

- **Changes installation method**: Replaces the step that installs `pm2` globally using `yarn` with a step that uses `bun` instead.
- **Sets explicit path for `pm2`**: Modifies the deployment script to use the explicit path `~/.bun/bin/pm2` for running `pm2` commands, ensuring the correct execution of `pm2` in the deployment environment.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/vanjaoljaca/vanjacloud.remote/issues/6?shareId=8bdf2bf4-6d86-4ccf-977e-cc587096224f).